### PR TITLE
refactor: make Contract generic for Compiler and add metadata to CompilerOutput

### DIFF
--- a/crates/compilers/src/artifact_output/configurable.rs
+++ b/crates/compilers/src/artifact_output/configurable.rs
@@ -169,11 +169,12 @@ impl ConfigurableArtifacts {
 
 impl ArtifactOutput for ConfigurableArtifacts {
     type Artifact = ConfigurableContractArtifact;
+    type CompilerContract = Contract;
 
     /// Writes extra files for compiled artifact based on [Self::additional_files]
     fn handle_artifacts(
         &self,
-        contracts: &crate::VersionedContracts,
+        contracts: &crate::VersionedContracts<Contract>,
         artifacts: &crate::Artifacts<Self::Artifact>,
     ) -> Result<(), SolcError> {
         for (file, contracts) in contracts.as_ref().iter() {

--- a/crates/compilers/src/artifact_output/hh.rs
+++ b/crates/compilers/src/artifact_output/hh.rs
@@ -13,6 +13,7 @@ pub struct HardhatArtifacts {
 
 impl ArtifactOutput for HardhatArtifacts {
     type Artifact = HardhatArtifact;
+    type CompilerContract = Contract;
 
     fn contract_to_artifact(
         &self,

--- a/crates/compilers/src/buildinfo.rs
+++ b/crates/compilers/src/buildinfo.rs
@@ -1,6 +1,8 @@
 //! Represents an entire build
 
-use crate::compilers::{CompilationError, CompilerInput, CompilerOutput, Language};
+use crate::compilers::{
+    CompilationError, CompilerContract, CompilerInput, CompilerOutput, Language,
+};
 use alloy_primitives::hex;
 use foundry_compilers_core::{error::Result, utils};
 use md5::Digest;
@@ -43,7 +45,7 @@ pub struct BuildContext<L> {
 }
 
 impl<L: Language> BuildContext<L> {
-    pub fn new<I, E>(input: &I, output: &CompilerOutput<E>) -> Result<Self>
+    pub fn new<I, E, C>(input: &I, output: &CompilerOutput<E, C>) -> Result<Self>
     where
         I: CompilerInput<Language = L>,
     {
@@ -87,9 +89,9 @@ pub struct RawBuildInfo<L> {
 
 impl<L: Language> RawBuildInfo<L> {
     /// Serializes a `BuildInfo` object
-    pub fn new<I: CompilerInput<Language = L>, E: CompilationError>(
+    pub fn new<I: CompilerInput<Language = L>, E: CompilationError, C: CompilerContract>(
         input: &I,
-        output: &CompilerOutput<E>,
+        output: &CompilerOutput<E, C>,
         full_build_info: bool,
     ) -> Result<Self> {
         let version = input.version().clone();
@@ -130,7 +132,7 @@ impl<L: Language> RawBuildInfo<L> {
 mod tests {
     use super::*;
     use crate::compilers::solc::SolcVersionedInput;
-    use foundry_compilers_artifacts::{sources::Source, Error, SolcLanguage, Sources};
+    use foundry_compilers_artifacts::{sources::Source, Contract, Error, SolcLanguage, Sources};
     use std::path::PathBuf;
 
     #[test]
@@ -142,9 +144,9 @@ mod tests {
             SolcLanguage::Solidity,
             v,
         );
-        let output = CompilerOutput::<Error>::default();
+        let output = CompilerOutput::<Error, Contract>::default();
         let raw_info = RawBuildInfo::new(&input, &output, true).unwrap();
-        let _info: BuildInfo<SolcVersionedInput, CompilerOutput<Error>> =
+        let _info: BuildInfo<SolcVersionedInput, CompilerOutput<Error, Contract>> =
             serde_json::from_str(&serde_json::to_string(&raw_info).unwrap()).unwrap();
     }
 }

--- a/crates/compilers/src/cache.rs
+++ b/crates/compilers/src/cache.rs
@@ -593,7 +593,11 @@ impl GroupedSources {
 /// A helper abstraction over the [`CompilerCache`] used to determine what files need to compiled
 /// and which `Artifacts` can be reused.
 #[derive(Debug)]
-pub(crate) struct ArtifactsCacheInner<'a, T: ArtifactOutput, C: Compiler> {
+pub(crate) struct ArtifactsCacheInner<
+    'a,
+    T: ArtifactOutput<CompilerContract = C::CompilerContract>,
+    C: Compiler,
+> {
     /// The preexisting cache file.
     pub cache: CompilerCache<C::Settings>,
 
@@ -622,7 +626,9 @@ pub(crate) struct ArtifactsCacheInner<'a, T: ArtifactOutput, C: Compiler> {
     pub content_hashes: HashMap<PathBuf, String>,
 }
 
-impl<'a, T: ArtifactOutput, C: Compiler> ArtifactsCacheInner<'a, T, C> {
+impl<'a, T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
+    ArtifactsCacheInner<'a, T, C>
+{
     /// Creates a new cache entry for the file
     fn create_cache_entry(&mut self, file: PathBuf, source: &Source) {
         let imports = self
@@ -845,20 +851,26 @@ impl<'a, T: ArtifactOutput, C: Compiler> ArtifactsCacheInner<'a, T, C> {
 /// Abstraction over configured caching which can be either non-existent or an already loaded cache
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
-pub(crate) enum ArtifactsCache<'a, T: ArtifactOutput, C: Compiler> {
+pub(crate) enum ArtifactsCache<
+    'a,
+    T: ArtifactOutput<CompilerContract = C::CompilerContract>,
+    C: Compiler,
+> {
     /// Cache nothing on disk
     Ephemeral(GraphEdges<C::ParsedSource>, &'a Project<C, T>),
     /// Handles the actual cached artifacts, detects artifacts that can be reused
     Cached(ArtifactsCacheInner<'a, T, C>),
 }
 
-impl<'a, T: ArtifactOutput, C: Compiler> ArtifactsCache<'a, T, C> {
+impl<'a, T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
+    ArtifactsCache<'a, T, C>
+{
     /// Create a new cache instance with the given files
     pub fn new(project: &'a Project<C, T>, edges: GraphEdges<C::ParsedSource>) -> Result<Self> {
         /// Returns the [CompilerCache] to use
         ///
         /// Returns a new empty cache if the cache does not exist or `invalidate_cache` is set.
-        fn get_cache<T: ArtifactOutput, C: Compiler>(
+        fn get_cache<T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>(
             project: &Project<C, T>,
             invalidate_cache: bool,
         ) -> CompilerCache<C::Settings> {

--- a/crates/compilers/src/compile/output/contracts.rs
+++ b/crates/compilers/src/compile/output/contracts.rs
@@ -67,7 +67,6 @@ where
     /// ```
     pub fn find_first(&self, contract_name: &str) -> Option<CompactContractRef<'_>> {
         self.contracts().find_map(|(name, contract)| {
-            //(name == contract_name).then(|| CompactContractRef::from(contract))
             (name == contract_name).then(|| contract.as_compact_contract_ref())
         })
     }

--- a/crates/compilers/src/compile/output/contracts.rs
+++ b/crates/compilers/src/compile/output/contracts.rs
@@ -1,6 +1,6 @@
-use crate::ArtifactId;
+use crate::{compilers::CompilerContract, ArtifactId};
 use foundry_compilers_artifacts::{
-    CompactContractBytecode, CompactContractRef, Contract, FileToContractsMap,
+    CompactContractBytecode, CompactContractRef, FileToContractsMap,
 };
 use semver::Version;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -11,11 +11,25 @@ use std::{
 };
 
 /// file -> [(contract name  -> Contract + solc version)]
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct VersionedContracts(pub FileToContractsMap<Vec<VersionedContract>>);
+pub struct VersionedContracts<C: CompilerContract>(
+    pub FileToContractsMap<Vec<VersionedContract<C>>>,
+);
 
-impl VersionedContracts {
+impl<C> Default for VersionedContracts<C>
+where
+    C: CompilerContract,
+{
+    fn default() -> Self {
+        Self(BTreeMap::new())
+    }
+}
+
+impl<C> VersionedContracts<C>
+where
+    C: CompilerContract,
+{
     /// Converts all `\\` separators in _all_ paths to `/`
     pub fn slash_paths(&mut self) {
         #[cfg(windows)]
@@ -53,7 +67,8 @@ impl VersionedContracts {
     /// ```
     pub fn find_first(&self, contract_name: &str) -> Option<CompactContractRef<'_>> {
         self.contracts().find_map(|(name, contract)| {
-            (name == contract_name).then(|| CompactContractRef::from(contract))
+            //(name == contract_name).then(|| CompactContractRef::from(contract))
+            (name == contract_name).then(|| contract.as_compact_contract_ref())
         })
     }
 
@@ -75,7 +90,7 @@ impl VersionedContracts {
     ) -> Option<CompactContractRef<'_>> {
         self.contracts_with_files().find_map(|(path, name, contract)| {
             (path == contract_path && name == contract_name)
-                .then(|| CompactContractRef::from(contract))
+                .then(|| contract.as_compact_contract_ref())
         })
     }
 
@@ -90,7 +105,7 @@ impl VersionedContracts {
     /// let contract = contracts.remove_first("Greeter").unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
-    pub fn remove_first(&mut self, contract_name: &str) -> Option<Contract> {
+    pub fn remove_first(&mut self, contract_name: &str) -> Option<C> {
         self.0.values_mut().find_map(|all_contracts| {
             let mut contract = None;
             if let Some((c, mut contracts)) = all_contracts.remove_entry(contract_name) {
@@ -116,7 +131,7 @@ impl VersionedContracts {
     /// let contract = contracts.remove("src/Greeter.sol".as_ref(), "Greeter").unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
-    pub fn remove(&mut self, path: &Path, contract_name: &str) -> Option<Contract> {
+    pub fn remove(&mut self, path: &Path, contract_name: &str) -> Option<C> {
         let (key, mut all_contracts) = self.0.remove_entry(path)?;
         let mut contract = None;
         if let Some((c, mut contracts)) = all_contracts.remove_entry(contract_name) {
@@ -142,18 +157,18 @@ impl VersionedContracts {
             .and_then(|contracts| {
                 contracts.get(contract).and_then(|c| c.first().map(|c| &c.contract))
             })
-            .map(CompactContractRef::from)
+            .map(|c| c.as_compact_contract_ref())
     }
 
     /// Returns an iterator over all contracts and their names.
-    pub fn contracts(&self) -> impl Iterator<Item = (&String, &Contract)> {
+    pub fn contracts(&self) -> impl Iterator<Item = (&String, &C)> {
         self.0
             .values()
             .flat_map(|c| c.iter().flat_map(|(name, c)| c.iter().map(move |c| (name, &c.contract))))
     }
 
     /// Returns an iterator over (`file`, `name`, `Contract`).
-    pub fn contracts_with_files(&self) -> impl Iterator<Item = (&PathBuf, &String, &Contract)> {
+    pub fn contracts_with_files(&self) -> impl Iterator<Item = (&PathBuf, &String, &C)> {
         self.0.iter().flat_map(|(file, contracts)| {
             contracts
                 .iter()
@@ -164,7 +179,7 @@ impl VersionedContracts {
     /// Returns an iterator over (`file`, `name`, `Contract`, `Version`).
     pub fn contracts_with_files_and_version(
         &self,
-    ) -> impl Iterator<Item = (&PathBuf, &String, &Contract, &Version)> {
+    ) -> impl Iterator<Item = (&PathBuf, &String, &C, &Version)> {
         self.0.iter().flat_map(|(file, contracts)| {
             contracts.iter().flat_map(move |(name, c)| {
                 c.iter().map(move |c| (file, name, &c.contract, &c.version))
@@ -173,7 +188,7 @@ impl VersionedContracts {
     }
 
     /// Returns an iterator over all contracts and their source names.
-    pub fn into_contracts(self) -> impl Iterator<Item = (String, Contract)> {
+    pub fn into_contracts(self) -> impl Iterator<Item = (String, C)> {
         self.0.into_values().flat_map(|c| {
             c.into_iter()
                 .flat_map(|(name, c)| c.into_iter().map(move |c| (name.clone(), c.contract)))
@@ -181,7 +196,7 @@ impl VersionedContracts {
     }
 
     /// Returns an iterator over (`file`, `name`, `Contract`)
-    pub fn into_contracts_with_files(self) -> impl Iterator<Item = (PathBuf, String, Contract)> {
+    pub fn into_contracts_with_files(self) -> impl Iterator<Item = (PathBuf, String, C)> {
         self.0.into_iter().flat_map(|(file, contracts)| {
             contracts.into_iter().flat_map(move |(name, c)| {
                 let file = file.clone();
@@ -193,7 +208,7 @@ impl VersionedContracts {
     /// Returns an iterator over (`file`, `name`, `Contract`, `Version`)
     pub fn into_contracts_with_files_and_version(
         self,
-    ) -> impl Iterator<Item = (PathBuf, String, Contract, Version)> {
+    ) -> impl Iterator<Item = (PathBuf, String, C, Version)> {
         self.0.into_iter().flat_map(|(file, contracts)| {
             contracts.into_iter().flat_map(move |(name, c)| {
                 let file = file.clone();
@@ -226,30 +241,42 @@ impl VersionedContracts {
     }
 }
 
-impl AsRef<FileToContractsMap<Vec<VersionedContract>>> for VersionedContracts {
-    fn as_ref(&self) -> &FileToContractsMap<Vec<VersionedContract>> {
+impl<C> AsRef<FileToContractsMap<Vec<VersionedContract<C>>>> for VersionedContracts<C>
+where
+    C: CompilerContract,
+{
+    fn as_ref(&self) -> &FileToContractsMap<Vec<VersionedContract<C>>> {
         &self.0
     }
 }
 
-impl AsMut<FileToContractsMap<Vec<VersionedContract>>> for VersionedContracts {
-    fn as_mut(&mut self) -> &mut FileToContractsMap<Vec<VersionedContract>> {
+impl<C> AsMut<FileToContractsMap<Vec<VersionedContract<C>>>> for VersionedContracts<C>
+where
+    C: CompilerContract,
+{
+    fn as_mut(&mut self) -> &mut FileToContractsMap<Vec<VersionedContract<C>>> {
         &mut self.0
     }
 }
 
-impl Deref for VersionedContracts {
-    type Target = FileToContractsMap<Vec<VersionedContract>>;
+impl<C> Deref for VersionedContracts<C>
+where
+    C: CompilerContract,
+{
+    type Target = FileToContractsMap<Vec<VersionedContract<C>>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl IntoIterator for VersionedContracts {
-    type Item = (PathBuf, BTreeMap<String, Vec<VersionedContract>>);
+impl<C> IntoIterator for VersionedContracts<C>
+where
+    C: CompilerContract,
+{
+    type Item = (PathBuf, BTreeMap<String, Vec<VersionedContract<C>>>);
     type IntoIter =
-        std::collections::btree_map::IntoIter<PathBuf, BTreeMap<String, Vec<VersionedContract>>>;
+        std::collections::btree_map::IntoIter<PathBuf, BTreeMap<String, Vec<VersionedContract<C>>>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
@@ -258,8 +285,8 @@ impl IntoIterator for VersionedContracts {
 
 /// A contract and the compiler version used to compile it
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct VersionedContract {
-    pub contract: Contract,
+pub struct VersionedContract<C: CompilerContract> {
+    pub contract: C,
     pub version: Version,
     pub build_id: String,
 }

--- a/crates/compilers/src/compile/output/mod.rs
+++ b/crates/compilers/src/compile/output/mod.rs
@@ -575,7 +575,7 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
         let build_id = build_info.id.clone();
         self.build_infos.push(build_info);
 
-        let CompilerOutput { errors, sources, contracts } = output;
+        let CompilerOutput { errors, sources, contracts, .. } = output;
         self.errors.extend(errors);
 
         for (path, source_file) in sources {

--- a/crates/compilers/src/compilers/mod.rs
+++ b/crates/compilers/src/compilers/mod.rs
@@ -1,11 +1,12 @@
 use crate::ProjectPathsConfig;
+use alloy_json_abi::JsonAbi;
 use core::fmt;
 use foundry_compilers_artifacts::{
     error::SourceLocation,
     output_selection::OutputSelection,
     remappings::Remapping,
     sources::{Source, Sources},
-    Contract, FileToContractsMap, Severity, SourceFile,
+    BytecodeObject, CompactContractRef, Contract, FileToContractsMap, Severity, SourceFile,
 };
 use foundry_compilers_core::error::Result;
 use semver::{Version, VersionReq};
@@ -183,16 +184,16 @@ pub trait CompilationError:
 /// Output of the compiler, including contracts, sources and errors. Currently only generic over the
 /// error but might be extended in the future.
 #[derive(Debug, Serialize, Deserialize)]
-pub struct CompilerOutput<E> {
+pub struct CompilerOutput<E, C> {
     #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
     pub errors: Vec<E>,
-    #[serde(default)]
-    pub contracts: FileToContractsMap<Contract>,
+    #[serde(default = "BTreeMap::new")]
+    pub contracts: FileToContractsMap<C>,
     #[serde(default)]
     pub sources: BTreeMap<PathBuf, SourceFile>,
 }
 
-impl<E> CompilerOutput<E> {
+impl<E, C> CompilerOutput<E, C> {
     /// Retains only those files the given iterator yields
     ///
     /// In other words, removes all contracts for files not included in the iterator
@@ -226,7 +227,7 @@ impl<E> CompilerOutput<E> {
             .collect();
     }
 
-    pub fn map_err<F, O: FnMut(E) -> F>(self, op: O) -> CompilerOutput<F> {
+    pub fn map_err<F, O: FnMut(E) -> F>(self, op: O) -> CompilerOutput<F, C> {
         CompilerOutput {
             errors: self.errors.into_iter().map(op).collect(),
             contracts: self.contracts,
@@ -235,7 +236,7 @@ impl<E> CompilerOutput<E> {
     }
 }
 
-impl<E> Default for CompilerOutput<E> {
+impl<E, C> Default for CompilerOutput<E, C> {
     fn default() -> Self {
         Self { errors: Vec::new(), contracts: BTreeMap::new(), sources: BTreeMap::new() }
     }
@@ -249,6 +250,42 @@ pub trait Language:
     const FILE_EXTENSIONS: &'static [&'static str];
 }
 
+pub trait CompilerContract: Serialize + Send + Sync + Debug + Clone + Eq + Sized {
+    fn abi_ref(&self) -> Option<&JsonAbi>;
+    fn bin_ref(&self) -> Option<&BytecodeObject>;
+    fn bin_runtime_ref(&self) -> Option<&BytecodeObject>;
+
+    fn as_compact_contract_ref(&self) -> CompactContractRef<'_> {
+        CompactContractRef {
+            abi: self.abi_ref(),
+            bin: self.bin_ref(),
+            bin_runtime: self.bin_runtime_ref(),
+        }
+    }
+}
+
+impl CompilerContract for Contract {
+    fn abi_ref(&self) -> Option<&JsonAbi> {
+        self.abi.as_ref()
+    }
+    fn bin_ref(&self) -> Option<&BytecodeObject> {
+        if let Some(ref evm) = self.evm {
+            evm.bytecode.as_ref().map(|c| &c.object)
+        } else {
+            None
+        }
+    }
+    fn bin_runtime_ref(&self) -> Option<&BytecodeObject> {
+        if let Some(ref evm) = self.evm {
+            evm.deployed_bytecode
+                .as_ref()
+                .and_then(|deployed| deployed.bytecode.as_ref().map(|evm| &evm.object))
+        } else {
+            None
+        }
+    }
+}
+
 /// The main compiler abstraction trait.
 ///
 /// Currently mostly represents a wrapper around compiler binary aware of the version and able to
@@ -259,6 +296,8 @@ pub trait Compiler: Send + Sync + Clone {
     type Input: CompilerInput<Settings = Self::Settings, Language = Self::Language>;
     /// Error type returned by the compiler.
     type CompilationError: CompilationError;
+    /// Output data for each contract
+    type CompilerContract: CompilerContract;
     /// Source parser used for resolving imports and version requirements.
     type ParsedSource: ParsedSource<Language = Self::Language>;
     /// Compiler settings.
@@ -269,7 +308,10 @@ pub trait Compiler: Send + Sync + Clone {
     /// Main entrypoint for the compiler. Compiles given input into [CompilerOutput]. Takes
     /// ownership over the input and returns back version with potential modifications made to it.
     /// Returned input is always the one which was seen by the binary.
-    fn compile(&self, input: &Self::Input) -> Result<CompilerOutput<Self::CompilationError>>;
+    fn compile(
+        &self,
+        input: &Self::Input,
+    ) -> Result<CompilerOutput<Self::CompilationError, Self::CompilerContract>>;
 
     /// Returns all versions available locally and remotely. Should return versions with stripped
     /// metadata.

--- a/crates/compilers/src/compilers/mod.rs
+++ b/crates/compilers/src/compilers/mod.rs
@@ -191,6 +191,8 @@ pub struct CompilerOutput<E, C> {
     pub contracts: FileToContractsMap<C>,
     #[serde(default)]
     pub sources: BTreeMap<PathBuf, SourceFile>,
+    #[serde(default)]
+    pub metadata: BTreeMap<String, String>,
 }
 
 impl<E, C> CompilerOutput<E, C> {
@@ -232,13 +234,19 @@ impl<E, C> CompilerOutput<E, C> {
             errors: self.errors.into_iter().map(op).collect(),
             contracts: self.contracts,
             sources: self.sources,
+            metadata: self.metadata,
         }
     }
 }
 
 impl<E, C> Default for CompilerOutput<E, C> {
     fn default() -> Self {
-        Self { errors: Vec::new(), contracts: BTreeMap::new(), sources: BTreeMap::new() }
+        Self {
+            errors: Vec::new(),
+            contracts: BTreeMap::new(),
+            sources: BTreeMap::new(),
+            metadata: BTreeMap::new(),
+        }
     }
 }
 

--- a/crates/compilers/src/compilers/multi.rs
+++ b/crates/compilers/src/compilers/multi.rs
@@ -17,7 +17,7 @@ use foundry_compilers_artifacts::{
     output_selection::OutputSelection,
     remappings::Remapping,
     sources::{Source, Sources},
-    Error, Severity, SolcLanguage,
+    Contract, Error, Severity, SolcLanguage,
 };
 use foundry_compilers_core::error::{Result, SolcError};
 use semver::Version;
@@ -259,8 +259,12 @@ impl Compiler for MultiCompiler {
     type ParsedSource = MultiCompilerParsedSource;
     type Settings = MultiCompilerSettings;
     type Language = MultiCompilerLanguage;
+    type CompilerContract = Contract;
 
-    fn compile(&self, input: &Self::Input) -> Result<CompilerOutput<Self::CompilationError>> {
+    fn compile(
+        &self,
+        input: &Self::Input,
+    ) -> Result<CompilerOutput<Self::CompilationError, Self::CompilerContract>> {
         match input {
             MultiCompilerInput::Solc(input) => {
                 if let Some(solc) = &self.solc {

--- a/crates/compilers/src/compilers/solc/mod.rs
+++ b/crates/compilers/src/compilers/solc/mod.rs
@@ -17,7 +17,7 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     ops::{Deref, DerefMut},
     path::{Path, PathBuf},
 };
@@ -67,6 +67,7 @@ impl Compiler for SolcCompiler {
             errors: solc_output.errors,
             contracts: solc_output.contracts,
             sources: solc_output.sources,
+            metadata: BTreeMap::new(),
         };
 
         Ok(output)
@@ -354,6 +355,7 @@ mod tests {
             errors: out.errors,
             contracts: Default::default(),
             sources: Default::default(),
+            metadata: Default::default(),
         };
 
         let v: Version = "0.8.12".parse().unwrap();

--- a/crates/compilers/src/compilers/solc/mod.rs
+++ b/crates/compilers/src/compilers/solc/mod.rs
@@ -9,7 +9,7 @@ use foundry_compilers_artifacts::{
     output_selection::OutputSelection,
     remappings::Remapping,
     sources::{Source, Sources},
-    Error, Settings, Severity, SolcInput,
+    Contract, Error, Settings, Severity, SolcInput,
 };
 use foundry_compilers_core::error::Result;
 use itertools::Itertools;
@@ -44,8 +44,12 @@ impl Compiler for SolcCompiler {
     type ParsedSource = SolData;
     type Settings = SolcSettings;
     type Language = SolcLanguage;
+    type CompilerContract = Contract;
 
-    fn compile(&self, input: &Self::Input) -> Result<CompilerOutput<Self::CompilationError>> {
+    fn compile(
+        &self,
+        input: &Self::Input,
+    ) -> Result<CompilerOutput<Self::CompilationError, Self::CompilerContract>> {
         let mut solc = match self {
             Self::Specific(solc) => solc.clone(),
 

--- a/crates/compilers/src/compilers/vyper/mod.rs
+++ b/crates/compilers/src/compilers/vyper/mod.rs
@@ -2,7 +2,7 @@ use self::{input::VyperVersionedInput, parser::VyperParsedSource};
 use super::{Compiler, CompilerOutput, Language};
 pub use crate::artifacts::vyper::{VyperCompilationError, VyperInput, VyperOutput, VyperSettings};
 use core::fmt;
-use foundry_compilers_artifacts::sources::Source;
+use foundry_compilers_artifacts::{sources::Source, Contract};
 use foundry_compilers_core::error::{Result, SolcError};
 use semver::Version;
 use serde::{de::DeserializeOwned, Serialize};
@@ -197,8 +197,12 @@ impl Compiler for Vyper {
     type ParsedSource = VyperParsedSource;
     type Input = VyperVersionedInput;
     type Language = VyperLanguage;
+    type CompilerContract = Contract;
 
-    fn compile(&self, input: &Self::Input) -> Result<CompilerOutput<VyperCompilationError>> {
+    fn compile(
+        &self,
+        input: &Self::Input,
+    ) -> Result<CompilerOutput<VyperCompilationError, Contract>> {
         self.compile(input).map(Into::into)
     }
 

--- a/crates/compilers/src/compilers/vyper/output.rs
+++ b/crates/compilers/src/compilers/vyper/output.rs
@@ -12,6 +12,7 @@ impl From<VyperOutput> for super::CompilerOutput<VyperCompilationError, Contract
                 .map(|(k, v)| (k, v.into_iter().map(|(k, v)| (k, v.into())).collect()))
                 .collect(),
             sources: output.sources.into_iter().map(|(k, v)| (k, v.into())).collect(),
+            metadata: Default::default(),
         }
     }
 }

--- a/crates/compilers/src/compilers/vyper/output.rs
+++ b/crates/compilers/src/compilers/vyper/output.rs
@@ -1,6 +1,8 @@
+use foundry_compilers_artifacts::Contract;
+
 use crate::artifacts::vyper::{VyperCompilationError, VyperOutput};
 
-impl From<VyperOutput> for super::CompilerOutput<VyperCompilationError> {
+impl From<VyperOutput> for super::CompilerOutput<VyperCompilationError, Contract> {
     fn from(output: VyperOutput) -> Self {
         Self {
             errors: output.errors,

--- a/crates/compilers/src/flatten.rs
+++ b/crates/compilers/src/flatten.rs
@@ -2,7 +2,7 @@ use crate::{
     compilers::{Compiler, ParsedSource},
     filter::MaybeSolData,
     resolver::parse::SolData,
-    CompilerSettings, Graph, Project, ProjectPathsConfig,
+    ArtifactOutput, CompilerSettings, Graph, Project, ProjectPathsConfig,
 };
 use foundry_compilers_artifacts::{
     ast::{visitor::Visitor, *},
@@ -204,8 +204,8 @@ pub struct Flattener {
 
 impl Flattener {
     /// Compiles the target file and prepares AST and analysis data for flattening.
-    pub fn new<C: Compiler>(
-        mut project: Project<C>,
+    pub fn new<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>>(
+        mut project: Project<C, T>,
         target: &Path,
     ) -> std::result::Result<Self, FlattenerError>
     where

--- a/crates/compilers/src/lib.rs
+++ b/crates/compilers/src/lib.rs
@@ -52,7 +52,7 @@ use derivative::Derivative;
 use foundry_compilers_artifacts::solc::{
     output_selection::OutputSelection,
     sources::{Source, SourceCompilationKind, Sources},
-    Contract, Severity, SourceFile, StandardJsonCompilerInput,
+    Severity, SourceFile, StandardJsonCompilerInput,
 };
 use foundry_compilers_core::error::{Result, SolcError, SolcIoError};
 use output::sources::{VersionedSourceFile, VersionedSourceFiles};
@@ -69,7 +69,10 @@ use std::{
 /// Represents a project workspace and handles `solc` compiling of all contracts in that workspace.
 #[derive(Clone, Derivative)]
 #[derivative(Debug)]
-pub struct Project<C: Compiler = MultiCompiler, T: ArtifactOutput = ConfigurableArtifacts> {
+pub struct Project<
+    C: Compiler = MultiCompiler,
+    T: ArtifactOutput<CompilerContract = C::CompilerContract> = ConfigurableArtifacts,
+> {
     pub compiler: C,
     /// Compiler versions locked for specific languages.
     pub locked_versions: HashMap<C::Language, Version>,
@@ -137,14 +140,14 @@ impl Project {
     }
 }
 
-impl<T: ArtifactOutput, C: Compiler> Project<C, T> {
+impl<T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler> Project<C, T> {
     /// Returns the handler that takes care of processing all artifacts
     pub fn artifacts_handler(&self) -> &T {
         &self.artifacts
     }
 }
 
-impl<C: Compiler, T: ArtifactOutput> Project<C, T>
+impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> Project<C, T>
 where
     C::Settings: Into<SolcSettings>,
 {
@@ -190,7 +193,7 @@ where
     }
 }
 
-impl<T: ArtifactOutput, C: Compiler> Project<C, T> {
+impl<T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler> Project<C, T> {
     /// Returns the path to the artifacts directory
     pub fn artifacts_path(&self) -> &PathBuf {
         &self.paths.artifacts
@@ -443,7 +446,10 @@ impl<T: ArtifactOutput, C: Compiler> Project<C, T> {
     }
 }
 
-pub struct ProjectBuilder<C: Compiler = MultiCompiler, T: ArtifactOutput = ConfigurableArtifacts> {
+pub struct ProjectBuilder<
+    C: Compiler = MultiCompiler,
+    T: ArtifactOutput<CompilerContract = C::CompilerContract> = ConfigurableArtifacts,
+> {
     /// The layout of the
     paths: Option<ProjectPathsConfig<C::Language>>,
     /// Compiler versions locked for specific languages.
@@ -473,7 +479,7 @@ pub struct ProjectBuilder<C: Compiler = MultiCompiler, T: ArtifactOutput = Confi
     sparse_output: Option<Box<dyn FileFilter>>,
 }
 
-impl<C: Compiler, T: ArtifactOutput> ProjectBuilder<C, T> {
+impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> ProjectBuilder<C, T> {
     /// Create a new builder with the given artifacts handler
     pub fn new(artifacts: T) -> Self {
         Self {
@@ -628,7 +634,10 @@ impl<C: Compiler, T: ArtifactOutput> ProjectBuilder<C, T> {
     }
 
     /// Set arbitrary `ArtifactOutputHandler`
-    pub fn artifacts<A: ArtifactOutput>(self, artifacts: A) -> ProjectBuilder<C, A> {
+    pub fn artifacts<A: ArtifactOutput<CompilerContract = C::CompilerContract>>(
+        self,
+        artifacts: A,
+    ) -> ProjectBuilder<C, A> {
         let Self {
             paths,
             cached,
@@ -710,18 +719,23 @@ impl<C: Compiler, T: ArtifactOutput> ProjectBuilder<C, T> {
     }
 }
 
-impl<C: Compiler, T: ArtifactOutput + Default> Default for ProjectBuilder<C, T> {
+impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract> + Default> Default
+    for ProjectBuilder<C, T>
+{
     fn default() -> Self {
         Self::new(T::default())
     }
 }
 
-impl<T: ArtifactOutput, C: Compiler> ArtifactOutput for Project<C, T> {
+impl<T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler> ArtifactOutput
+    for Project<C, T>
+{
     type Artifact = T::Artifact;
+    type CompilerContract = C::CompilerContract;
 
     fn on_output<CP>(
         &self,
-        contracts: &VersionedContracts,
+        contracts: &VersionedContracts<C::CompilerContract>,
         sources: &VersionedSourceFiles,
         layout: &ProjectPathsConfig<CP>,
         ctx: OutputContext<'_>,
@@ -731,7 +745,7 @@ impl<T: ArtifactOutput, C: Compiler> ArtifactOutput for Project<C, T> {
 
     fn handle_artifacts(
         &self,
-        contracts: &VersionedContracts,
+        contracts: &VersionedContracts<C::CompilerContract>,
         artifacts: &Artifacts<Self::Artifact>,
     ) -> Result<()> {
         self.artifacts_handler().handle_artifacts(contracts, artifacts)
@@ -777,7 +791,7 @@ impl<T: ArtifactOutput, C: Compiler> ArtifactOutput for Project<C, T> {
         &self,
         file: &Path,
         name: &str,
-        contract: Contract,
+        contract: C::CompilerContract,
         source_file: Option<&SourceFile>,
     ) -> Self::Artifact {
         self.artifacts_handler().contract_to_artifact(file, name, contract, source_file)
@@ -785,7 +799,7 @@ impl<T: ArtifactOutput, C: Compiler> ArtifactOutput for Project<C, T> {
 
     fn output_to_artifacts<CP>(
         &self,
-        contracts: &VersionedContracts,
+        contracts: &VersionedContracts<C::CompilerContract>,
         sources: &VersionedSourceFiles,
         ctx: OutputContext<'_>,
         layout: &ProjectPathsConfig<CP>,

--- a/crates/compilers/src/project_util/mod.rs
+++ b/crates/compilers/src/project_util/mod.rs
@@ -31,14 +31,20 @@ pub mod mock;
 /// A [`Project`] wrapper that lives in a new temporary directory
 ///
 /// Once `TempProject` is dropped, the temp dir is automatically removed, see [`TempDir::drop()`]
-pub struct TempProject<C: Compiler = MultiCompiler, T: ArtifactOutput = ConfigurableArtifacts> {
+pub struct TempProject<
+    C: Compiler = MultiCompiler,
+    T: ArtifactOutput<CompilerContract = C::CompilerContract> = ConfigurableArtifacts,
+> {
     /// temporary workspace root
     _root: TempDir,
     /// actual project workspace with the `root` tempdir as its root
     inner: Project<C, T>,
 }
 
-impl<T: ArtifactOutput + Default> TempProject<MultiCompiler, T> {
+impl<
+        T: ArtifactOutput<CompilerContract = <MultiCompiler as Compiler>::CompilerContract> + Default,
+    > TempProject<MultiCompiler, T>
+{
     /// Creates a new temp project using the provided paths and artifacts handler.
     /// sets the project root to a temp dir
     #[cfg(feature = "svm-solc")]
@@ -69,7 +75,10 @@ impl<T: ArtifactOutput + Default> TempProject<MultiCompiler, T> {
     }
 }
 
-impl<T: ArtifactOutput + Default> TempProject<MultiCompiler, T> {
+impl<
+        T: ArtifactOutput<CompilerContract = <MultiCompiler as Compiler>::CompilerContract> + Default,
+    > TempProject<MultiCompiler, T>
+{
     /// Creates a new temp project for the given `PathStyle`
     #[cfg(feature = "svm-solc")]
     pub fn with_style(prefix: &str, style: PathStyle) -> Result<Self> {
@@ -81,7 +90,10 @@ impl<T: ArtifactOutput + Default> TempProject<MultiCompiler, T> {
     }
 }
 
-impl<T: ArtifactOutput> fmt::Debug for TempProject<MultiCompiler, T> {
+impl<
+        T: ArtifactOutput<CompilerContract = <MultiCompiler as Compiler>::CompilerContract> + Default,
+    > fmt::Debug for TempProject<MultiCompiler, T>
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TempProject").field("paths", &self.inner.paths).finish()
     }
@@ -121,7 +133,11 @@ impl TempProject<MultiCompiler, HardhatArtifacts> {
     }
 }
 
-impl<C: Compiler + Default, T: ArtifactOutput + Default> TempProject<C, T> {
+impl<
+        C: Compiler + Default,
+        T: ArtifactOutput<CompilerContract = C::CompilerContract> + Default,
+    > TempProject<C, T>
+{
     /// Makes sure all resources are created
     pub fn create_new(
         root: TempDir,
@@ -466,8 +482,9 @@ impl TempProject {
     }
 }
 
-impl<T: ArtifactOutput + Default> AsRef<Project<MultiCompiler, T>>
-    for TempProject<MultiCompiler, T>
+impl<
+        T: ArtifactOutput<CompilerContract = <MultiCompiler as Compiler>::CompilerContract> + Default,
+    > AsRef<Project<MultiCompiler, T>> for TempProject<MultiCompiler, T>
 {
     fn as_ref(&self) -> &Project<MultiCompiler, T> {
         self.project()

--- a/crates/compilers/tests/project.rs
+++ b/crates/compilers/tests/project.rs
@@ -20,8 +20,8 @@ use foundry_compilers::{
     ProjectBuilder, ProjectCompileOutput, ProjectPathsConfig, TestFileFilter,
 };
 use foundry_compilers_artifacts::{
-    output_selection::OutputSelection, remappings::Remapping, BytecodeHash, DevDoc, Error,
-    ErrorDoc, EventDoc, Libraries, MethodDoc, ModelCheckerEngine::CHC, ModelCheckerSettings,
+    output_selection::OutputSelection, remappings::Remapping, BytecodeHash, Contract, DevDoc,
+    Error, ErrorDoc, EventDoc, Libraries, MethodDoc, ModelCheckerEngine::CHC, ModelCheckerSettings,
     Settings, Severity, SolcInput, UserDoc, UserDocNotice,
 };
 use foundry_compilers_core::{
@@ -403,7 +403,8 @@ contract B { }
     let mut build_info_count = 0;
     for entry in fs::read_dir(info_dir).unwrap() {
         let _info =
-            BuildInfo::<SolcInput, CompilerOutput<Error>>::read(&entry.unwrap().path()).unwrap();
+            BuildInfo::<SolcInput, CompilerOutput<Error, Contract>>::read(&entry.unwrap().path())
+                .unwrap();
         build_info_count += 1;
     }
     assert_eq!(build_info_count, 1);
@@ -445,7 +446,8 @@ contract B { }
     let mut build_info_count = 0;
     for entry in fs::read_dir(info_dir).unwrap() {
         let _info =
-            BuildInfo::<SolcInput, CompilerOutput<Error>>::read(&entry.unwrap().path()).unwrap();
+            BuildInfo::<SolcInput, CompilerOutput<Error, Contract>>::read(&entry.unwrap().path())
+                .unwrap();
         build_info_count += 1;
     }
     assert_eq!(build_info_count, 1);


### PR DESCRIPTION
Right now the compiler abstraction has two couplings that force foundry-zksync to implement it's [own fork of compilers](https://github.com/Moonsong-Labs/compilers/tree/zksync-v0.11.6):
1. `Contract` is specific to `solc`/EVM contracts. Era VM contracts, while requiring different fields, still could use most of the functionality of the `compilers` pipeline.
2. `CompilerOutput` has `solc` specific fields. `zksolc` compilation has relevant information that is useful to have later on, for example when storing `BuildInfo`

This PR implements changes to address this. If implemented, it would allow `foundry-zksync` to get rid of all overrides and only maintain ZKsync specific data structures/trait implementations. See [sample PR](https://github.com/Moonsong-Labs/compilers/pull/42). Changes include:
1. Make `Compiler` generic over `Contract`.
2. Add `metadata` field to `CompilerOutput` in order to add arbitrary data to compilation output.
